### PR TITLE
[한병하] 사진 슬라이드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,10 @@ Android 학습 프로젝트 #2
 > - ```SquareSlide``` 에는 RGB값을 필수속성으로 추가하였고, ```ImageSlide```에는 image 데이터가 들어갈 변수를 필수속성으로 추가하였다.
 > - ```SlideAdapter```에는 ViewType을 분기하여 해당하는 데이터 클래스에서 해당하는 뷰를 띄워주게 구현하였다.
 > - ```ItemTouchHelper.Callback()``` 을 사용하여 Drag&Drop으로 순서를 바꿀 수 있게 구현하였다.
+
+> ## 5. 사진 슬라이드 추가하기
+> 230721 PM 2:00
+> - 슬라이드 목록에서 특정 요소를 길게 터치하면 PopupMenu가 뜬다. 4개의 기능을 활용하여 슬라이드의 순서를 바꿀 수 있다.
+> - ```GestureDetector.SimpleOnGestureListener()``` 를 활용하여 더블클릭을 감지 한 후, 이미지 슬라이드일 경우 갤러리를 오픈한다.
+> - ```registerForActivityResult```를 활용하여 갤러리에서 선택한 사진을 받아온 후, ```getByteArrayFromUri```를 사용하여 ByteArray로 이미지 정보를 저장한다.
+> - 이미지 상단 정렬을 위해서 ConstraintSet에서 제약정보를 동적으로 변경하였다.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,5 +44,6 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
     implementation  'androidx.activity:activity-ktx:1.7.2'
-
+    implementation 'com.github.bumptech.glide:glide:4.13.2'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.13.2'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/glacier/androidslide/MainActivity.kt
+++ b/app/src/main/java/com/glacier/androidslide/MainActivity.kt
@@ -60,6 +60,7 @@ class MainActivity : AppCompatActivity(), OnClickListener, OnSlideSelectedListen
 
     fun setObserver() {
         slideViewModel.nowSlide.observe(this) {
+            Log.d("TEST", it.alpha.toString())
             setSlideView(it)
         }
 

--- a/app/src/main/java/com/glacier/androidslide/MainActivity.kt
+++ b/app/src/main/java/com/glacier/androidslide/MainActivity.kt
@@ -1,8 +1,10 @@
 package com.glacier.androidslide
 
+import android.content.Intent
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
+import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
@@ -17,6 +19,9 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.glacier.androidslide.adapter.SlideAdapter
 import com.glacier.androidslide.databinding.ActivityMainBinding
+import com.glacier.androidslide.databinding.ItemSlideImageBinding
+import com.glacier.androidslide.databinding.ItemSlideSquareBinding
+import com.glacier.androidslide.listener.OnSlideDoubleClickListener
 import com.glacier.androidslide.listener.OnSlideSelectedListener
 import com.glacier.androidslide.model.ImageSlide
 import com.glacier.androidslide.model.Slide
@@ -27,7 +32,8 @@ import com.glacier.androidslide.util.ItemMoveCallback
 import com.glacier.androidslide.util.SlideType
 import com.glacier.androidslide.viewmodel.MainViewModel
 
-class MainActivity : AppCompatActivity(), OnClickListener, OnSlideSelectedListener {
+class MainActivity : AppCompatActivity(), OnClickListener, OnSlideSelectedListener,
+    OnSlideDoubleClickListener {
 
     private val binding by lazy { ActivityMainBinding.inflate(layoutInflater) }
     private val slideViewModel: MainViewModel by viewModels()
@@ -85,7 +91,7 @@ class MainActivity : AppCompatActivity(), OnClickListener, OnSlideSelectedListen
     }
 
     private fun setRecyclerView(slides: List<Slide>) {
-        val slideAdapter = SlideAdapter(slides as MutableList<Slide>, this@MainActivity)
+        val slideAdapter = SlideAdapter(slides as MutableList<Slide>, this@MainActivity, this@MainActivity)
 
         with(binding.rvSlides) {
             adapter = slideAdapter
@@ -176,8 +182,22 @@ class MainActivity : AppCompatActivity(), OnClickListener, OnSlideSelectedListen
         }
     }
 
-    override fun onSlideSelected(position: Int, slide: Slide) {
+    override fun onSlideSelected(slideType: SlideType, position: Int, slide: Slide) {
         Log.d("DBG::SELECTED", "$position $slide")
+        when (slideType) {
+            SlideType.SQUARE -> {
+
+            }
+
+            SlideType.IMAGE -> {
+
+            }
+        }
         slideViewModel.setSlideIndex(position)
     }
+
+    override fun onSlideDoubleClicked(position: Int, slide: Slide) {
+    }
+
+
 }

--- a/app/src/main/java/com/glacier/androidslide/MainActivity.kt
+++ b/app/src/main/java/com/glacier/androidslide/MainActivity.kt
@@ -16,7 +16,6 @@ import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.provider.MediaStore
-import android.util.Log
 import android.view.View
 import android.view.View.OnClickListener
 import android.widget.ImageView
@@ -78,7 +77,6 @@ class MainActivity : AppCompatActivity(), OnClickListener, OnSlideSelectedListen
 
     fun setObserver() {
         slideViewModel.nowSlide.observe(this) {
-            Log.d("TEST", it.alpha.toString())
             setSlideView(it)
         }
 

--- a/app/src/main/java/com/glacier/androidslide/MainActivity.kt
+++ b/app/src/main/java/com/glacier/androidslide/MainActivity.kt
@@ -69,20 +69,20 @@ class MainActivity : AppCompatActivity(), OnClickListener, OnSlideSelectedListen
     }
 
     private fun setSlideView(slide: Slide) {
-            when (slide) {
-                is SquareSlide -> {
-                    binding.ivSlide.setImageDrawable(
-                        ColorDrawable(Color.argb(slide.alpha, slide.r, slide.g ,slide.b))
-                    )
-                    binding.tvAlphaMonitor.text = UtilManager.getAlphaToMode(slide.alpha).toString()
-                    binding.btnBgcolor.text = UtilManager.rgbToHex(slide.r, slide.g ,slide.b)
-                    setBgColorBtnColor(slide.alpha, slide.r, slide.g ,slide.b)
-                }
-
-                is ImageSlide -> {
-                    // TODO :: 추후 이미지 슬라이드 처리
-                }
+        when (slide) {
+            is SquareSlide -> {
+                binding.ivSlide.setImageDrawable(
+                    ColorDrawable(Color.argb(slide.alpha, slide.r, slide.g, slide.b))
+                )
+                binding.tvAlphaMonitor.text = UtilManager.getAlphaToMode(slide.alpha).toString()
+                binding.btnBgcolor.text = UtilManager.rgbToHex(slide.r, slide.g, slide.b)
+                setBgColorBtnColor(slide.alpha, slide.r, slide.g, slide.b)
             }
+
+            is ImageSlide -> {
+                // TODO :: 추후 이미지 슬라이드 처리
+            }
+        }
     }
 
     private fun setBgColorBtnColor(alpha: Int, R: Int, G: Int, B: Int) {
@@ -91,7 +91,8 @@ class MainActivity : AppCompatActivity(), OnClickListener, OnSlideSelectedListen
     }
 
     private fun setRecyclerView(slides: List<Slide>) {
-        val slideAdapter = SlideAdapter(slides as MutableList<Slide>, this@MainActivity, this@MainActivity)
+        val slideAdapter =
+            SlideAdapter(slides as MutableList<Slide>, this@MainActivity, this@MainActivity)
 
         with(binding.rvSlides) {
             adapter = slideAdapter

--- a/app/src/main/java/com/glacier/androidslide/MainActivity.kt
+++ b/app/src/main/java/com/glacier/androidslide/MainActivity.kt
@@ -171,7 +171,7 @@ class MainActivity : AppCompatActivity(), OnClickListener, OnSlideSelectedListen
             }
 
             R.id.btn_add_slide -> {
-                slideViewModel.setNewSlide(SlideType.SQUARE) // 추후 랜덤으로 변경
+                slideViewModel.setNewSlide(SlideType.values().random()) // 추후 랜덤으로 변경
             }
         }
     }

--- a/app/src/main/java/com/glacier/androidslide/MainActivity.kt
+++ b/app/src/main/java/com/glacier/androidslide/MainActivity.kt
@@ -9,7 +9,6 @@ import android.util.Log
 import android.view.View
 import android.view.View.OnClickListener
 import android.widget.ImageView
-import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -26,12 +25,12 @@ import com.glacier.androidslide.util.UtilManager
 import com.glacier.androidslide.model.SquareSlide
 import com.glacier.androidslide.util.ItemMoveCallback
 import com.glacier.androidslide.util.SlideType
-import com.glacier.androidslide.viewmodel.SquareSlideViewModel
+import com.glacier.androidslide.viewmodel.MainViewModel
 
 class MainActivity : AppCompatActivity(), OnClickListener, OnSlideSelectedListener {
 
     private val binding by lazy { ActivityMainBinding.inflate(layoutInflater) }
-    private val slideViewModel: SquareSlideViewModel by viewModels()
+    private val slideViewModel: MainViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/glacier/androidslide/SlideManager.kt
+++ b/app/src/main/java/com/glacier/androidslide/SlideManager.kt
@@ -1,5 +1,6 @@
 package com.glacier.androidslide
 
+import android.util.Log
 import com.glacier.androidslide.model.ImageSlide
 import com.glacier.androidslide.model.Slide
 import com.glacier.androidslide.model.SquareSlide

--- a/app/src/main/java/com/glacier/androidslide/SlideManager.kt
+++ b/app/src/main/java/com/glacier/androidslide/SlideManager.kt
@@ -1,6 +1,5 @@
 package com.glacier.androidslide
 
-import android.util.Log
 import com.glacier.androidslide.model.ImageSlide
 import com.glacier.androidslide.model.Slide
 import com.glacier.androidslide.model.SquareSlide

--- a/app/src/main/java/com/glacier/androidslide/SlideManager.kt
+++ b/app/src/main/java/com/glacier/androidslide/SlideManager.kt
@@ -39,9 +39,9 @@ class SlideManager() {
     fun editSlideAlpha(index: Int, alpha: Int) {
         if (slideList.isNotEmpty()) {
             val slide = slideList[index]
-            if(slide is SquareSlide){
+            if (slide is SquareSlide) {
                 slideList[index] = slide.copy(alpha = alpha)
-            }else if(slide is ImageSlide){
+            } else if (slide is ImageSlide) {
                 slideList[index] = slide.copy(alpha = alpha)
             }
         }
@@ -50,11 +50,18 @@ class SlideManager() {
     fun setNowSlideSelected(index: Int, selected: Boolean) {
         if (slideList.isNotEmpty()) {
             val slide = slideList[index]
-            if(slide is SquareSlide){
+            if (slide is SquareSlide) {
                 slideList[index] = slide.copy(selected = selected)
-            }else if(slide is ImageSlide){
+            } else if (slide is ImageSlide) {
                 slideList[index] = slide.copy(selected = selected)
             }
+        }
+    }
+
+    fun editSlideImage(index: Int, image: ByteArray) {
+        if (slideList.isNotEmpty()) {
+            val slide = slideList[index] as ImageSlide
+            slideList[index] = slide.copy(image = image)
         }
     }
 }

--- a/app/src/main/java/com/glacier/androidslide/adapter/SlideAdapter.kt
+++ b/app/src/main/java/com/glacier/androidslide/adapter/SlideAdapter.kt
@@ -1,11 +1,15 @@
 package com.glacier.androidslide.adapter
 
 import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Color
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.appcompat.widget.PopupMenu
 import androidx.recyclerview.widget.RecyclerView
+import com.glacier.androidslide.R
 import com.glacier.androidslide.databinding.ItemSlideImageBinding
 import com.glacier.androidslide.databinding.ItemSlideSquareBinding
 import com.glacier.androidslide.listener.ItemMoveListener
@@ -14,7 +18,6 @@ import com.glacier.androidslide.model.ImageSlide
 import com.glacier.androidslide.model.Slide
 import com.glacier.androidslide.model.SquareSlide
 import com.glacier.androidslide.util.SlideType
-import java.util.Collections
 
 class SlideAdapter(
     private val slides: MutableList<Slide>,
@@ -48,6 +51,76 @@ class SlideAdapter(
             listener.onSlideSelected(position, slide)
         }
 
+        holder.itemView.setOnLongClickListener {
+            val context = holder.itemView.context
+            PopupMenu(context, holder.itemView).apply {
+                menuInflater.inflate(R.menu.slide_item_menu, menu)
+                setOnMenuItemClickListener { item ->
+                    when (item.itemId) {
+                        R.id.menu_hard_back -> {
+                            showToast(
+                                context,
+                                context.getString(R.string.menu_toast_hard_back)
+                            )
+
+                            val lastPosition = slides.size - 1
+                            if (position < lastPosition) {
+                                val slideToMove = slides.removeAt(position)
+                                slides.add(slideToMove)
+                                notifyItemMoved(position, lastPosition)
+                                notifyItemRangeChanged(position, slides.size - position)
+                            }
+                            true
+                        }
+
+                        R.id.menu_back -> {
+                            showToast(context, context.getString(R.string.menu_toast_back))
+
+                            val nextPosition = position + 1
+                            if (position < slides.size - 1) {
+                                val slideToMove = slides.removeAt(position)
+                                slides.add(nextPosition, slideToMove)
+                                notifyItemMoved(position, nextPosition)
+                                notifyItemRangeChanged(position - 1, 3)
+                            }
+                            true
+                        }
+
+                        R.id.menu_hard_front -> {
+                            showToast(context, context.getString(R.string.menu_toast_hard_front))
+
+                            if (position > 0) {
+                                val slideToMove = slides.removeAt(position)
+                                slides.add(0, slideToMove)
+                                notifyItemMoved(position, 0)
+                                notifyItemRangeChanged(0, position + 1)
+                            }
+                            true
+                        }
+
+                        R.id.menu_front -> {
+                            showToast(context, context.getString(R.string.menu_toast_front))
+
+                            if (position > 0) {
+                                val prevPosition = position - 1
+                                val slideToMove = slides.removeAt(position)
+                                slides.add(prevPosition, slideToMove)
+                                notifyItemMoved(position, prevPosition)
+                                notifyItemRangeChanged(prevPosition, 3)
+                            }
+                            true
+                        }
+
+                        else -> false
+                    }
+                }
+                show()
+            }
+
+            return@setOnLongClickListener true
+        }
+
+
         when (holder) {
             is SquareSlideViewHolder -> {
                 val squareSlide = slide as SquareSlide
@@ -79,7 +152,7 @@ class SlideAdapter(
         slides.removeAt(fromPosition)
         slides.add(toPosition, slide)
 
-        Log.d("DTEST","TEST")
+        Log.d("DTEST", "TEST")
         notifyItemMoved(fromPosition, toPosition)
         notifyItemChanged(fromPosition)
         notifyItemChanged(toPosition)
@@ -91,6 +164,14 @@ class SlideAdapter(
         fun bind(squareSlide: SquareSlide) {
             // todo: 정사각형 슬라이드 처리하기
             binding.tvSlideNumber.text = "${adapterPosition + 1}"
+            binding.ivSlide.setColorFilter(
+                Color.argb(
+                    squareSlide.alpha,
+                    squareSlide.R,
+                    squareSlide.G,
+                    squareSlide.B
+                )
+            )
         }
     }
 
@@ -100,5 +181,9 @@ class SlideAdapter(
             // todo: 이미지 슬라이드 처리하기
             binding.tvSlideNumber.text = "${adapterPosition + 1}"
         }
+    }
+
+    fun showToast(context: Context, text: String) {
+        Toast.makeText(context, text, Toast.LENGTH_SHORT).show()
     }
 }

--- a/app/src/main/java/com/glacier/androidslide/adapter/SlideAdapter.kt
+++ b/app/src/main/java/com/glacier/androidslide/adapter/SlideAdapter.kt
@@ -12,6 +12,7 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.appcompat.widget.PopupMenu
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import com.glacier.androidslide.R
 import com.glacier.androidslide.databinding.ItemSlideImageBinding
 import com.glacier.androidslide.databinding.ItemSlideSquareBinding
@@ -166,7 +167,7 @@ class SlideAdapter(
             // todo: 정사각형 슬라이드 처리하기
 
             itemView.setOnClickListener {
-                listener.onSlideSelected(SlideType.SQUARE, adapterPosition, squareSlide)
+                listener.onSlideSelected(adapterPosition, squareSlide)
             }
 
             binding.tvSlideNumber.text = "${adapterPosition + 1}"
@@ -185,9 +186,10 @@ class SlideAdapter(
         RecyclerView.ViewHolder(binding.root) {
         fun bind(imageSlide: ImageSlide) {
             // todo: 이미지 슬라이드 처리하기
+            Glide.with(binding.root.context).load(imageSlide.image).error(R.drawable.outline_image_24).override(50,50).into(binding.ivSlide)
 
             itemView.setOnClickListener {
-                listener.onSlideSelected(SlideType.IMAGE, adapterPosition, imageSlide)
+                listener.onSlideSelected(adapterPosition, imageSlide)
             }
 
             itemView.setOnTouchListener(object : View.OnTouchListener {

--- a/app/src/main/java/com/glacier/androidslide/adapter/SlideAdapter.kt
+++ b/app/src/main/java/com/glacier/androidslide/adapter/SlideAdapter.kt
@@ -37,14 +37,15 @@ class SlideAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
-        val binding = when (viewType) {
-            VIEW_TYPE_SQUARE -> ItemSlideSquareBinding.inflate(inflater, parent, false)
-            VIEW_TYPE_IMAGE -> ItemSlideImageBinding.inflate(inflater, parent, false)
-            else -> throw IllegalArgumentException("Invalid ViewType")
-        }
         return when (viewType) {
-            VIEW_TYPE_SQUARE -> SquareSlideViewHolder(binding as ItemSlideSquareBinding)
-            VIEW_TYPE_IMAGE -> ImageSlideViewHolder(binding as ItemSlideImageBinding)
+            VIEW_TYPE_SQUARE -> {
+                SquareSlideViewHolder(ItemSlideSquareBinding.inflate(inflater, parent, false))
+            }
+
+            VIEW_TYPE_IMAGE -> {
+                ImageSlideViewHolder(ItemSlideImageBinding.inflate(inflater, parent, false))
+            }
+
             else -> throw IllegalArgumentException("Invalid ViewType")
         }
     }
@@ -184,7 +185,8 @@ class SlideAdapter(
         RecyclerView.ViewHolder(binding.root) {
         fun bind(imageSlide: ImageSlide) {
             // todo: 이미지 슬라이드 처리하기
-            Glide.with(binding.root.context).load(imageSlide.image).error(R.drawable.outline_image_24).override(50,50).into(binding.ivSlide)
+            Glide.with(binding.root.context).load(imageSlide.image)
+                .error(R.drawable.outline_image_24).override(50, 50).into(binding.ivSlide)
 
             itemView.setOnClickListener {
                 listener.onSlideSelected(adapterPosition, imageSlide)
@@ -192,12 +194,17 @@ class SlideAdapter(
 
             itemView.setOnTouchListener(object : View.OnTouchListener {
                 private val gestureDetector =
-                    GestureDetector(itemView.context, object : GestureDetector.SimpleOnGestureListener() {
-                        override fun onDoubleTap(e: MotionEvent): Boolean {
-                            doubleClickListener.onSlideDoubleClicked(adapterPosition, slides[adapterPosition])
-                            return true
-                        }
-                    })
+                    GestureDetector(
+                        itemView.context,
+                        object : GestureDetector.SimpleOnGestureListener() {
+                            override fun onDoubleTap(e: MotionEvent): Boolean {
+                                doubleClickListener.onSlideDoubleClicked(
+                                    adapterPosition,
+                                    slides[adapterPosition]
+                                )
+                                return true
+                            }
+                        })
 
                 override fun onTouch(v: View?, event: MotionEvent): Boolean {
                     return gestureDetector.onTouchEvent(event)

--- a/app/src/main/java/com/glacier/androidslide/adapter/SlideAdapter.kt
+++ b/app/src/main/java/com/glacier/androidslide/adapter/SlideAdapter.kt
@@ -4,7 +4,10 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
 import android.util.Log
+import android.view.GestureDetector
 import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.appcompat.widget.PopupMenu
@@ -13,6 +16,7 @@ import com.glacier.androidslide.R
 import com.glacier.androidslide.databinding.ItemSlideImageBinding
 import com.glacier.androidslide.databinding.ItemSlideSquareBinding
 import com.glacier.androidslide.listener.ItemMoveListener
+import com.glacier.androidslide.listener.OnSlideDoubleClickListener
 import com.glacier.androidslide.listener.OnSlideSelectedListener
 import com.glacier.androidslide.model.ImageSlide
 import com.glacier.androidslide.model.Slide
@@ -21,7 +25,8 @@ import com.glacier.androidslide.util.SlideType
 
 class SlideAdapter(
     private val slides: MutableList<Slide>,
-    private val listener: OnSlideSelectedListener
+    private val listener: OnSlideSelectedListener,
+    private val doubleClickListener: OnSlideDoubleClickListener
 ) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>(), ItemMoveListener {
 
@@ -46,10 +51,6 @@ class SlideAdapter(
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         val slide = slides[position]
-
-        holder.itemView.setOnClickListener {
-            listener.onSlideSelected(position, slide)
-        }
 
         holder.itemView.setOnLongClickListener {
             val context = holder.itemView.context
@@ -163,6 +164,11 @@ class SlideAdapter(
         RecyclerView.ViewHolder(binding.root) {
         fun bind(squareSlide: SquareSlide) {
             // todo: 정사각형 슬라이드 처리하기
+
+            itemView.setOnClickListener {
+                listener.onSlideSelected(SlideType.SQUARE, adapterPosition, squareSlide)
+            }
+
             binding.tvSlideNumber.text = "${adapterPosition + 1}"
             binding.ivSlide.setColorFilter(
                 Color.argb(
@@ -179,6 +185,25 @@ class SlideAdapter(
         RecyclerView.ViewHolder(binding.root) {
         fun bind(imageSlide: ImageSlide) {
             // todo: 이미지 슬라이드 처리하기
+
+            itemView.setOnClickListener {
+                listener.onSlideSelected(SlideType.IMAGE, adapterPosition, imageSlide)
+            }
+
+            itemView.setOnTouchListener(object : View.OnTouchListener {
+                private val gestureDetector =
+                    GestureDetector(itemView.context, object : GestureDetector.SimpleOnGestureListener() {
+                        override fun onDoubleTap(e: MotionEvent): Boolean {
+                            doubleClickListener.onSlideDoubleClicked(adapterPosition, slides[adapterPosition])
+                            return true
+                        }
+                    })
+
+                override fun onTouch(v: View?, event: MotionEvent): Boolean {
+                    return gestureDetector.onTouchEvent(event)
+                }
+            })
+
             binding.tvSlideNumber.text = "${adapterPosition + 1}"
         }
     }

--- a/app/src/main/java/com/glacier/androidslide/adapter/SlideAdapter.kt
+++ b/app/src/main/java/com/glacier/androidslide/adapter/SlideAdapter.kt
@@ -173,9 +173,9 @@ class SlideAdapter(
             binding.ivSlide.setColorFilter(
                 Color.argb(
                     squareSlide.alpha,
-                    squareSlide.R,
-                    squareSlide.G,
-                    squareSlide.B
+                    squareSlide.r,
+                    squareSlide.g,
+                    squareSlide.b
                 )
             )
         }

--- a/app/src/main/java/com/glacier/androidslide/adapter/SlideAdapter.kt
+++ b/app/src/main/java/com/glacier/androidslide/adapter/SlideAdapter.kt
@@ -3,7 +3,6 @@ package com.glacier.androidslide.adapter
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
-import android.util.Log
 import android.view.GestureDetector
 import android.view.LayoutInflater
 import android.view.MotionEvent
@@ -154,7 +153,6 @@ class SlideAdapter(
         slides.removeAt(fromPosition)
         slides.add(toPosition, slide)
 
-        Log.d("DTEST", "TEST")
         notifyItemMoved(fromPosition, toPosition)
         notifyItemChanged(fromPosition)
         notifyItemChanged(toPosition)

--- a/app/src/main/java/com/glacier/androidslide/listener/OnSlideDoubleClickListener.kt
+++ b/app/src/main/java/com/glacier/androidslide/listener/OnSlideDoubleClickListener.kt
@@ -3,6 +3,6 @@ package com.glacier.androidslide.listener
 import com.glacier.androidslide.model.Slide
 import com.glacier.androidslide.util.SlideType
 
-interface OnSlideSelectedListener {
-    fun onSlideSelected(slideType: SlideType, position: Int, slide: Slide)
+interface OnSlideDoubleClickListener {
+    fun onSlideDoubleClicked(position: Int, slide: Slide)
 }

--- a/app/src/main/java/com/glacier/androidslide/listener/OnSlideSelectedListener.kt
+++ b/app/src/main/java/com/glacier/androidslide/listener/OnSlideSelectedListener.kt
@@ -4,5 +4,5 @@ import com.glacier.androidslide.model.Slide
 import com.glacier.androidslide.util.SlideType
 
 interface OnSlideSelectedListener {
-    fun onSlideSelected(slideType: SlideType, position: Int, slide: Slide)
+    fun onSlideSelected(position: Int, slide: Slide)
 }

--- a/app/src/main/java/com/glacier/androidslide/model/ImageSlide.kt
+++ b/app/src/main/java/com/glacier/androidslide/model/ImageSlide.kt
@@ -7,10 +7,25 @@ data class ImageSlide(
     override val side: Int,
     override val alpha: Int,
     override val selected: Boolean,
-    val image: String,
+    val image: ByteArray,
 ) : Slide {
     override val slideType: SlideType = SlideType.IMAGE
     override fun toString(): String {
         return "$slideType - ($id), Side:$side, Image:$image, Alpha:$alpha, Selected:$selected"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ImageSlide
+
+        if (!image.contentEquals(other.image)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return image.contentHashCode()
     }
 }

--- a/app/src/main/java/com/glacier/androidslide/model/SquareSlide.kt
+++ b/app/src/main/java/com/glacier/androidslide/model/SquareSlide.kt
@@ -11,7 +11,7 @@ data class SquareSlide(
     val g: Int,
     val b: Int,
 
-) : Slide {
+    ) : Slide {
     override val slideType: SlideType = SlideType.SQUARE
     override fun toString(): String {
         return "$slideType - ($id), Side:$side, R:$r, G:$g, B:$b, Alpha:$alpha, Selected:$selected"

--- a/app/src/main/java/com/glacier/androidslide/model/SquareSlideViewFactory.kt
+++ b/app/src/main/java/com/glacier/androidslide/model/SquareSlideViewFactory.kt
@@ -11,7 +11,7 @@ object SquareSlideViewFactory : SquareSlideFactory {
 
         return when(slideType){
             SlideType.SQUARE -> SquareSlide(id, side, alpha, true, r, g, b)
-            SlideType.IMAGE -> ImageSlide(id, side, alpha, true, "")
+            SlideType.IMAGE -> ImageSlide(id, side, alpha, true, ByteArray(0))
         }
     }
 }

--- a/app/src/main/java/com/glacier/androidslide/util/ItemMoveCallback.kt
+++ b/app/src/main/java/com/glacier/androidslide/util/ItemMoveCallback.kt
@@ -30,7 +30,6 @@ class ItemMoveCallback(private val listener: ItemMoveListener) :
         viewHolder: RecyclerView.ViewHolder,
         target: RecyclerView.ViewHolder
     ): Boolean {
-        Log.d("DBG::DRAG","MOVE ${viewHolder.adapterPosition} ${target.adapterPosition}")
         listener.onItemMove(viewHolder.adapterPosition, target.adapterPosition)
         return true
     }

--- a/app/src/main/java/com/glacier/androidslide/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/glacier/androidslide/viewmodel/MainViewModel.kt
@@ -1,16 +1,14 @@
 package com.glacier.androidslide.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.glacier.androidslide.SlideManager
 import com.glacier.androidslide.model.Slide
-import com.glacier.androidslide.model.SquareSlide
 import com.glacier.androidslide.util.Mode
 import com.glacier.androidslide.util.SlideType
 import com.glacier.androidslide.util.UtilManager
 
-class SquareSlideViewModel : ViewModel() {
+class MainViewModel : ViewModel() {
     private val slideManager = SlideManager()
 
     var nowAlpha: Int = 10

--- a/app/src/main/java/com/glacier/androidslide/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/glacier/androidslide/viewmodel/MainViewModel.kt
@@ -73,7 +73,6 @@ class MainViewModel : ViewModel() {
     fun setNowSlideSelected(selected: Boolean) {
         slideManager.setNowSlideSelected(nowSlideIndex, selected)
         getNowSlide()
-
     }
 
     fun editColorRandom() {
@@ -100,6 +99,11 @@ class MainViewModel : ViewModel() {
         nowSlideIndex = slideManager.getSlideCount() - 1
         getNowSlide()
         getSlides()
+    }
 
+    fun editSlideImage(index: Int, image: ByteArray){
+        slideManager.editSlideImage(index, image)
+        getNowSlide()
+        getSlides()
     }
 }

--- a/app/src/main/java/com/glacier/androidslide/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/glacier/androidslide/viewmodel/MainViewModel.kt
@@ -21,8 +21,8 @@ class MainViewModel : ViewModel() {
     val slides = _slides
 
 
-    fun getNowSlide(): Slide? {
-        return slideManager.getSlideByIndex(nowSlideIndex)
+    fun getNowSlide() {
+        _nowSlide.value = slideManager.getSlideByIndex(nowSlideIndex)
     }
 
     fun getSlideWithIndex(index: Int): Slide? {
@@ -83,6 +83,7 @@ class MainViewModel : ViewModel() {
             UtilManager.getRandomColor()[1],
             UtilManager.getRandomColor()[2]
         )
+        slides.postValue(slides.value)
         getNowSlide()
 
     }

--- a/app/src/main/java/com/glacier/androidslide/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/glacier/androidslide/viewmodel/MainViewModel.kt
@@ -67,6 +67,7 @@ class MainViewModel : ViewModel() {
         }
 
         getNowSlide()
+        getSlides()
     }
 
     fun setNowSlideSelected(selected: Boolean) {

--- a/app/src/main/res/layout-sw600dp/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp/activity_main.xml
@@ -55,6 +55,7 @@
         android:minWidth="300dp"
         android:minHeight="300dp"
         android:padding="3dp"
+        android:layout_margin="10dp"
         app:layout_constraintBottom_toBottomOf="@id/main_view"
         app:layout_constraintEnd_toEndOf="@id/main_view"
         app:layout_constraintStart_toStartOf="@id/main_view"

--- a/app/src/main/res/layout/item_slide_image.xml
+++ b/app/src/main/res/layout/item_slide_image.xml
@@ -12,7 +12,7 @@
         android:layout_width="wrap_content"
         android:layout_height="0dp"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.2" />
+        app:layout_constraintGuide_percent="0.3" />
 
     <TextView
         android:id="@+id/tv_slide_number"
@@ -22,7 +22,7 @@
         android:textSize="22sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toEndOf="@id/gl_start"
+        app:layout_constraintEnd_toStartOf="@id/main_view"
         tool:text="1" />
 
 
@@ -30,11 +30,10 @@
         android:id="@+id/main_view"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginStart="10dp"
         android:background="@drawable/bg_radius_outlined"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/tv_slide_number"
+        app:layout_constraintStart_toEndOf="@id/gl_start"
         app:layout_constraintTop_toTopOf="parent" />
 
     <ImageView

--- a/app/src/main/res/layout/item_slide_square.xml
+++ b/app/src/main/res/layout/item_slide_square.xml
@@ -12,7 +12,7 @@
         android:layout_width="wrap_content"
         android:layout_height="0dp"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.2" />
+        app:layout_constraintGuide_percent="0.3" />
 
     <TextView
         android:id="@+id/tv_slide_number"
@@ -22,7 +22,7 @@
         android:textSize="22sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toEndOf="@id/gl_start"
+        app:layout_constraintEnd_toStartOf="@id/main_view"
         tool:text="1" />
 
 
@@ -30,11 +30,10 @@
         android:id="@+id/main_view"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginStart="10dp"
         android:background="@drawable/bg_radius_outlined"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/tv_slide_number"
+        app:layout_constraintStart_toEndOf="@id/gl_start"
         app:layout_constraintTop_toTopOf="parent" />
 
     <ImageView

--- a/app/src/main/res/menu/slide_item_menu.xml
+++ b/app/src/main/res/menu/slide_item_menu.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/menu_hard_back"
+        android:title="맨 뒤로 보내기" />
+    <item
+        android:id="@+id/menu_back"
+        android:title="뒤로 보내기" />
+    <item
+        android:id="@+id/menu_hard_front"
+        android:title="맨 앞으로 보내기" />
+    <item
+        android:id="@+id/menu_front"
+        android:title="앞으로 보내기" />
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,10 @@
 <resources>
     <string name="app_name">AndroidSlide</string>
     <string name="text_btn_add_slide">( + )</string>
+
+    <string name="menu_toast_hard_back">슬라이드를 맨 뒤로 보냅니다.</string>
+    <string name="menu_toast_back">슬라이드를 뒤로 보냅니다.</string>
+    <string name="menu_toast_hard_front">슬라이드를 맨 앞으로 보냅니다.</string>
+    <string name="menu_toast_front">슬라이드를 앞으로 보냅니다.</string>
+
 </resources>


### PR DESCRIPTION
> ## 5. 사진 슬라이드 추가하기
> 230721 PM 2:00
> - 슬라이드 목록에서 특정 요소를 길게 터치하면 PopupMenu가 뜬다. 4개의 기능을 활용하여 슬라이드의 순서를 바꿀 수 있다.
> - ```GestureDetector.SimpleOnGestureListener()``` 를 활용하여 더블클릭을 감지 한 후, 이미지 슬라이드일 경우 갤러리를 오픈한다.
> - ```registerForActivityResult```를 활용하여 갤러리에서 선택한 사진을 받아온 후, ```getByteArrayFromUri```를 사용하여 ByteArray로 이미지 정보를 저장한다.
> - 이미지 상단 정렬을 위해서 ConstraintSet에서 제약정보를 동적으로 변경하였다.